### PR TITLE
Improve database migration by adding a default user name

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 export const users = pgTable("users", {
   id: serial("id").primaryKey(),
-  name: text("name").notNull(),
+  name: text("name").notNull().default("User"), // Default value for smooth migration
   username: text("username").notNull().unique(), // This will be the email
   status: text("status").notNull().default("Active"), // Active, Disabled
   type: text("type").notNull().default("User"), // User, Admin


### PR DESCRIPTION
Update the 'users' table schema to include a default value for the 'name' column, ensuring smooth data migrations when the schema changes.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 01b62781-afaa-4f80-b4f6-880acc3df867
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/fe593703-3b81-4f24-8498-3e5e868859fd/01b62781-afaa-4f80-b4f6-880acc3df867/liyA4Mb